### PR TITLE
Add fail to curl

### DIFF
--- a/release-automation/bump-version.sh
+++ b/release-automation/bump-version.sh
@@ -22,7 +22,7 @@ while read -r line; do
     else
         echo "asdf plugin $PLUGIN_NAME already added"
     fi
-done < .tool-versions
+done <.tool-versions
 
 asdf install
 
@@ -30,10 +30,10 @@ uv version "$VERSION"
 uv run ./compile_proto.sh
 
 # Update OpenAPI client
-curl -H "Authorization: token $GH_TOKEN" \
+curl --fail-with-body -sS -H "Authorization: token $GH_TOKEN" \
     -H "Accept: application/vnd.github.v3.raw" \
     -L "https://raw.githubusercontent.com/fishjam-cloud/fishjam/main/openapi.yaml" \
-     -o openapi.yaml
+    -o openapi.yaml
 
 uv run update_client ./openapi.yaml
 rm openapi.yaml


### PR DESCRIPTION
## Description

The asdf step fails and is overly complicated, we can just add `uv` on the runner

## Motivation and Context

Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here.

## Documentation impact

- [ ] Documentation update required
- [ ] Documentation updated [in another PR](_)
- [ ] No documentation update required

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
