### PR TITLE
feat: lower Python requirement to 3.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy: &strategy
       matrix:
-        python-version: ["3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "fishjam-server-sdk"
 version = "0.26.0"
 description = "Python server SDK for the Fishjam"
 authors = [{ name = "Fishjam Team", email = "contact@fishjam.io" }]
-requires-python = ">=3.11"
+requires-python = ">=3.10"
 readme = "README.md"
 license = "Apache-2.0"
 dependencies = [

--- a/tests/test_notifier.py
+++ b/tests/test_notifier.py
@@ -80,16 +80,19 @@ class TestConnectingToServer:
         def handle_notitifcation(_notification):
             pass
 
-        async with asyncio.TaskGroup() as tg:
-            notifier_task = tg.create_task(notifier.connect())
-            await notifier.wait_ready()
+        notifier_task = asyncio.ensure_future(notifier.connect())
+        await notifier.wait_ready()
 
-            assert (
-                notifier._websocket
-                and notifier._websocket.state == websockets.State.OPEN
-            )
+        assert (
+            notifier._websocket
+            and notifier._websocket.state == websockets.State.OPEN
+        )
 
-            notifier_task.cancel()
+        notifier_task.cancel()
+        try:
+            await notifier_task
+        except asyncio.CancelledError:
+            pass
 
 
 @pytest.fixture
@@ -114,20 +117,22 @@ class TestReceivingNotifications:
     ):
         event_checks = [ServerMessageRoomCreated, ServerMessageRoomDeleted]
 
-        async with asyncio.TaskGroup() as tg:
-            assert_task = tg.create_task(assert_events(notifier, event_checks.copy()))
+        assert_task = asyncio.ensure_future(assert_events(notifier, event_checks.copy()))
+        notifier_task = asyncio.ensure_future(notifier.connect())
+        await notifier.wait_ready()
 
-            notifier_task = tg.create_task(notifier.connect())
-            await notifier.wait_ready()
+        options = RoomOptions(webhook_url=WEBHOOK_URL)
+        room = room_api.create_room(options=options)
 
-            options = RoomOptions(webhook_url=WEBHOOK_URL)
-            room = room_api.create_room(options=options)
+        room_api.delete_room(room.id)
 
-            room_api.delete_room(room.id)
+        await assert_task
 
-            await assert_task
-
-            notifier_task.cancel()
+        notifier_task.cancel()
+        try:
+            await notifier_task
+        except asyncio.CancelledError:
+            pass
 
         self.assert_webhook_events(event_checks, event_queue, room.id)
 
@@ -144,28 +149,27 @@ class TestReceivingNotifications:
             ServerMessageRoomDeleted,
         ]
 
-        async with asyncio.TaskGroup() as tg:
-            assert_task = tg.create_task(assert_events(notifier, event_checks.copy()))
+        assert_task = asyncio.ensure_future(assert_events(notifier, event_checks.copy()))
+        notifier_task = asyncio.ensure_future(notifier.connect())
+        await notifier.wait_ready()
 
-            notifier_task = tg.create_task(notifier.connect())
-            await notifier.wait_ready()
+        options = RoomOptions(webhook_url=WEBHOOK_URL)
+        room = room_api.create_room(options=options)
 
-            options = RoomOptions(webhook_url=WEBHOOK_URL)
-            room = room_api.create_room(options=options)
+        peer, token = room_api.create_peer(room.id)
+        peer_socket = PeerSocket(fishjam_url=FISHJAM_ID)
+        peer_socket_task = asyncio.ensure_future(peer_socket.connect(token))
 
-            peer, token = room_api.create_peer(room.id)
-            peer_socket = PeerSocket(fishjam_url=FISHJAM_ID)
-            peer_socket_task = tg.create_task(peer_socket.connect(token))
+        await peer_socket.wait_ready()
 
-            await peer_socket.wait_ready()
+        room_api.delete_peer(room.id, peer.id)
+        room_api.delete_room(room.id)
 
-            room_api.delete_peer(room.id, peer.id)
-            room_api.delete_room(room.id)
+        await assert_task
 
-            await assert_task
-
-            notifier_task.cancel()
-            peer_socket_task.cancel()
+        notifier_task.cancel()
+        peer_socket_task.cancel()
+        await asyncio.gather(notifier_task, peer_socket_task, return_exceptions=True)
 
         self.assert_webhook_events(event_checks, event_queue, room.id)
 
@@ -181,27 +185,26 @@ class TestReceivingNotifications:
             ServerMessageRoomDeleted,
         ]
 
-        async with asyncio.TaskGroup() as tg:
-            assert_task = tg.create_task(assert_events(notifier, event_checks.copy()))
+        assert_task = asyncio.ensure_future(assert_events(notifier, event_checks.copy()))
+        notifier_task = asyncio.ensure_future(notifier.connect())
+        await notifier.wait_ready()
 
-            notifier_task = tg.create_task(notifier.connect())
-            await notifier.wait_ready()
+        options = RoomOptions(webhook_url=WEBHOOK_URL)
+        room = room_api.create_room(options=options)
+        _peer, token = room_api.create_peer(room.id)
 
-            options = RoomOptions(webhook_url=WEBHOOK_URL)
-            room = room_api.create_room(options=options)
-            _peer, token = room_api.create_peer(room.id)
+        peer_socket = PeerSocket(fishjam_url=FISHJAM_ID)
+        peer_socket_task = asyncio.ensure_future(peer_socket.connect(token))
 
-            peer_socket = PeerSocket(fishjam_url=FISHJAM_ID)
-            peer_socket_task = tg.create_task(peer_socket.connect(token))
+        await peer_socket.wait_ready()
 
-            await peer_socket.wait_ready()
+        room_api.delete_room(room.id)
 
-            room_api.delete_room(room.id)
+        await assert_task
 
-            await assert_task
-
-            notifier_task.cancel()
-            peer_socket_task.cancel()
+        notifier_task.cancel()
+        peer_socket_task.cancel()
+        await asyncio.gather(notifier_task, peer_socket_task, return_exceptions=True)
 
         self.assert_webhook_events(event_checks, event_queue, room.id)
 


### PR DESCRIPTION
## Summary

The minimum Python version was set to `>=3.11` despite the main library code being fully compatible with Python 3.10. The only 3.11-specific construct in the repository was `asyncio.TaskGroup`, which appeared exclusively in `tests/test_notifier.py`.

## Changes

- `pyproject.toml`: lower `requires-python` from `>=3.11` to `>=3.10`
- `tests/test_notifier.py`: replace all `asyncio.TaskGroup` usages with `asyncio.ensure_future` + `asyncio.gather`, which are available since Python 3.4 and 3.4 respectively
- `.github/workflows/ci.yml`: add `"3.10"` to the Python version matrix for both `type-check` and `test` jobs

## Motivation

Projects running Python 3.10 are currently blocked from upgrading past `fishjam-server-sdk==0.20.0`. This change unblocks them without affecting any existing Python 3.11+ users.

Made with [Cursor](https://cursor.com)