### PR TITLE
docs: add Cursor Cloud specific setup instructions to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,3 +11,10 @@ Whenever a new feature is added, follow the red-green TDD cycle:
 3. **Refactor** — clean up the implementation and tests while keeping the suite green.
 
 Do not write production code for a new feature before a failing test exists for it.
+
+## Cursor Cloud specific instructions
+
+`uv` is pre-installed; the startup script runs `uv sync`. Non-obvious notes:
+
+- Validated: `uv sync`, `uv run ruff check .`, and a smoke import (`uv run python -c "import fishjam"`).
+- The `tests/` suite is integration-oriented: `tests/conftest.py` imports `FISHJAM_ID` and `FISHJAM_MANAGEMENT_TOKEN` at collection time, so `uv run pytest` fails with `KeyError` unless those env vars are set and a live Fishjam server is reachable. The unit-style tests run with placeholders, e.g. `FISHJAM_ID=dummy FISHJAM_MANAGEMENT_TOKEN=dummy uv run pytest tests/test_config_validation.py tests/test_allowed_notifications.py`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Appends a `## Cursor Cloud specific instructions` section. No production code changes. Validated: `uv sync`, `uv run ruff check .`, smoke import; the `tests/` suite is integration-oriented (needs `FISHJAM_ID`/`FISHJAM_MANAGEMENT_TOKEN` + a live Fishjam), with unit-style tests runnable via placeholder env.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0d2d55e2-cb0f-49b0-8d5f-15c80c2982c8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0d2d55e2-cb0f-49b0-8d5f-15c80c2982c8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

