### PR TITLE
Add verify_webhook_signature helper for webhook authenticity

### DIFF
--- a/fishjam/__init__.py
+++ b/fishjam/__init__.py
@@ -12,7 +12,11 @@ from fishjam import agent, errors, events, integrations, peer, room, version
 from fishjam._openapi_client.models import PeerMetadata
 
 # API
-from fishjam._webhook_notifier import decode_server_notifications, receive_binary
+from fishjam._webhook_notifier import (
+    decode_server_notifications,
+    receive_binary,
+    verify_webhook_signature,
+)
 from fishjam._ws_notifier import FishjamNotifier
 from fishjam.api._fishjam_client import (
     AgentOptions,
@@ -34,6 +38,7 @@ __all__ = [
     "FishjamNotifier",
     "decode_server_notifications",
     "receive_binary",
+    "verify_webhook_signature",
     "PeerMetadata",
     "PeerOptions",
     "PeerOptionsVapi",

--- a/fishjam/_webhook_notifier.py
+++ b/fishjam/_webhook_notifier.py
@@ -1,5 +1,6 @@
 """Module for decoding received webhook notifications from Fishjam."""
 
+import hmac
 import warnings
 from typing import List, Union
 
@@ -67,6 +68,26 @@ def decode_server_notifications(binary: bytes) -> List[AllowedNotification]:
         return [content]
 
     return []
+
+
+def verify_webhook_signature(body: bytes, signature: str, secret: str) -> bool:
+    """Verify the `x-fishjam-signature-256` header of a raw webhook body.
+
+    Accepts the `sha256=<hex>` format sent by Fishjam (the prefix is
+    optional) and compares in constant time. Call this with the raw request
+    body before passing it to `decode_server_notifications`.
+
+    Args:
+        body: The raw binary body of the webhook request.
+        signature: The value of the `x-fishjam-signature-256` header.
+        secret: The webhook secret configured in Fishjam.
+
+    Returns:
+        bool: True when the signature matches the body, False otherwise.
+    """
+    expected = hmac.new(secret.encode(), body, "sha256").hexdigest()
+    provided = signature.strip().removeprefix("sha256=")
+    return hmac.compare_digest(provided, expected)
 
 
 def receive_binary(

--- a/tests/test_webhook_notifier.py
+++ b/tests/test_webhook_notifier.py
@@ -1,6 +1,12 @@
+import hmac
+
 import pytest
 
-from fishjam import decode_server_notifications, receive_binary
+from fishjam import (
+    decode_server_notifications,
+    receive_binary,
+    verify_webhook_signature,
+)
 from fishjam.events import (
     ServerMessagePeerConnected,
     ServerMessageRoomCreated,
@@ -171,3 +177,28 @@ def test_decode_empty_batch_returns_empty_list():
     )
 
     assert decode_server_notifications(binary) == []
+
+
+BODY = bytes(ServerMessage(room_created=ServerMessageRoomCreated(room_id="r1")))
+SECRET = "webhook-secret"
+SIGNATURE = hmac.new(SECRET.encode(), BODY, "sha256").hexdigest()
+
+
+def test_verify_valid_signature_with_prefix():
+    assert verify_webhook_signature(BODY, f"sha256={SIGNATURE}", SECRET)
+
+
+def test_verify_valid_signature_without_prefix():
+    assert verify_webhook_signature(BODY, SIGNATURE, SECRET)
+
+
+def test_verify_wrong_secret_fails():
+    assert not verify_webhook_signature(BODY, f"sha256={SIGNATURE}", "other-secret")
+
+
+def test_verify_tampered_body_fails():
+    assert not verify_webhook_signature(BODY + b"x", f"sha256={SIGNATURE}", SECRET)
+
+
+def test_verify_garbage_signature_fails():
+    assert not verify_webhook_signature(BODY, "sha256=nothex", SECRET)


### PR DESCRIPTION
## Description

Adds `verify_webhook_signature(body, signature, secret)` to `fishjam`: verifies the `x-fishjam-signature-256` header (GitHub-style `sha256=<hex>` HMAC-SHA256 of the raw body, prefix optional) using `hmac.compare_digest` for constant-time comparison. Exported next to `decode_server_notifications`; call it on the raw request body before decoding.

## Motivation and Context

Fishjam now signs webhook notifications. Without an SDK helper, users hand-roll verification with `==`, which is timing-attackable. Same helper already added to the JS server SDK.

## Documentation impact

- [ ] Documentation update required
- [ ] Documentation updated [in another PR](_)
- [x] No documentation update required

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)